### PR TITLE
Consider all threads when stealing

### DIFF
--- a/source/task_scheduler.cpp
+++ b/source/task_scheduler.cpp
@@ -280,7 +280,7 @@ bool TaskScheduler::GetNextTask(TaskBundle *nextTask) {
 
 	// Ours is empty, try to steal from the others'
 	currentThreadIndex = tls.LastSuccessfulSteal;
-	for (std::size_t i = 0; i < m_numThreads - 1; ++i) {
+	for (std::size_t i = 0; i < m_numThreads; ++i) {
 		ThreadLocalStorage &otherTLS = m_tls[(currentThreadIndex + i) % m_numThreads];
 		if (otherTLS.TaskQueue.Steal(nextTask)) {
 			tls.LastSuccessfulSteal = i;

--- a/source/task_scheduler.cpp
+++ b/source/task_scheduler.cpp
@@ -279,9 +279,13 @@ bool TaskScheduler::GetNextTask(TaskBundle *nextTask) {
 	}
 
 	// Ours is empty, try to steal from the others'
-	currentThreadIndex = tls.LastSuccessfulSteal;
+	std::size_t threadIndex = tls.LastSuccessfulSteal;
 	for (std::size_t i = 0; i < m_numThreads; ++i) {
-		ThreadLocalStorage &otherTLS = m_tls[(currentThreadIndex + i) % m_numThreads];
+		const std::size_t threadIndexToStealFrom = (threadIndex + i) % m_numThreads;
+		if (threadIndexToStealFrom == currentThreadIndex) {
+			continue;
+		}
+		ThreadLocalStorage &otherTLS = m_tls[threadIndexToStealFrom];
 		if (otherTLS.TaskQueue.Steal(nextTask)) {
 			tls.LastSuccessfulSteal = i;
 			return true;


### PR DESCRIPTION
I think now the code is not considering all the threads for stealing. This makes the triangle example (for example) run effectively single threaded, since it is accidentally skipping the main thread because tls.LastSuccessfulSteal is by default 1.

Before:

[==========] Running 4 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 2 tests from FiberAbstraction
[ RUN      ] FiberAbstraction.SingleFiberSwitch
[       OK ] FiberAbstraction.SingleFiberSwitch (0 ms)
[ RUN      ] FiberAbstraction.NestedFiberSwitch
[       OK ] FiberAbstraction.NestedFiberSwitch (0 ms)
[----------] 2 tests from FiberAbstraction (1 ms total)

[----------] 2 tests from FunctionalTests
[ RUN      ] FunctionalTests.ProducerConsumer
[       OK ] FunctionalTests.ProducerConsumer (538 ms)
[ RUN      ] FunctionalTests.CalcTriangleNum
[       OK ] FunctionalTests.CalcTriangleNum (31 ms)
[----------] 2 tests from FunctionalTests (572 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 2 test cases ran. (574 ms total)
[  PASSED  ] 4 tests.

After:

[==========] Running 4 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 2 tests from FiberAbstraction
[ RUN      ] FiberAbstraction.SingleFiberSwitch
[       OK ] FiberAbstraction.SingleFiberSwitch (0 ms)
[ RUN      ] FiberAbstraction.NestedFiberSwitch
[       OK ] FiberAbstraction.NestedFiberSwitch (0 ms)
[----------] 2 tests from FiberAbstraction (1 ms total)

[----------] 2 tests from FunctionalTests
[ RUN      ] FunctionalTests.ProducerConsumer
[       OK ] FunctionalTests.ProducerConsumer (179 ms)
[ RUN      ] FunctionalTests.CalcTriangleNum
[       OK ] FunctionalTests.CalcTriangleNum (10 ms)
[----------] 2 tests from FunctionalTests (191 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 2 test cases ran. (195 ms total)
[  PASSED  ] 4 tests.
