### PR TITLE
Task pinning

### DIFF
--- a/include/fiber_tasking_lib/task_scheduler.h
+++ b/include/fiber_tasking_lib/task_scheduler.h
@@ -186,7 +186,6 @@ public:
 	 */
 	void WaitForCounter(std::shared_ptr<std::atomic_uint> &counter, uint value);
 
-private:
 	/**
 	 * Gets the 0-based index of the current thread
 	 * This is useful for m_tls[GetCurrentThreadIndex()]
@@ -194,6 +193,8 @@ private:
 	 * @return    The index of the current thread
 	 */
 	std::size_t GetCurrentThreadIndex();
+
+private:
 	/**
 	 * Pops the next task off the queue into nextTask. If there are no tasks in the
 	 * the queue, it will return false.

--- a/include/fiber_tasking_lib/task_scheduler.h
+++ b/include/fiber_tasking_lib/task_scheduler.h
@@ -158,7 +158,7 @@ public:
 	 * @param fiberPoolSize     The size of the fiber pool. The fiber pool is used to run new tasks when the current task is waiting on a counter
 	 * @param mainTask          The main task to run
 	 * @param mainTaskArg       The argument to pass to 'mainTask'
-	 * @param threadPoolSize    The size of the thread pool to run. 0 corresponds to NumHarewareThreads()
+	 * @param threadPoolSize    The size of the thread pool to run. 0 corresponds to NumHardwareThreads()
 	 */
 	void Run(uint fiberPoolSize, TaskFunction mainTask, void *mainTaskArg = nullptr, uint threadPoolSize = 0);
 

--- a/include/fiber_tasking_lib/task_scheduler.h
+++ b/include/fiber_tasking_lib/task_scheduler.h
@@ -131,6 +131,8 @@ private:
 		WaitFreeQueue<TaskBundle> TaskQueue;
 		/* The last queue that we successfully stole from. This is an offset index from the current thread index */
 		std::size_t LastSuccessfulSteal;
+		/* List of pinned tasks to this thread */
+		std::vector<std::pair<std::size_t, WaitingBundle>> PinnedTasks;
 
 	private:
 		/* Cache-line pad */
@@ -181,10 +183,11 @@ public:
 	/**
 	 * Yields execution to another task until counter == value
 	 *
-	 * @param counter    The counter to check
-	 * @param value      The value to wait for
+	 * @param counter             The counter to check
+	 * @param value               The value to wait for
+	 * @param pinToCurrentThread  If true, the task invoking this call will not resume on a different thread
 	 */
-	void WaitForCounter(std::shared_ptr<std::atomic_uint> &counter, uint value);
+	void WaitForCounter(std::shared_ptr<std::atomic_uint> &counter, uint value, bool pinToCurrentThread = false);
 
 	/**
 	 * Gets the 0-based index of the current thread

--- a/source/task_scheduler.cpp
+++ b/source/task_scheduler.cpp
@@ -431,10 +431,10 @@ void TaskScheduler::WaitForCounter(std::shared_ptr<std::atomic_uint> &counter, u
 	WaitingBundle bundle{ counter.get(), value };
 
 	if (pinToCurrentThread) {
-		// If task is pinned, put WaitingBundle in local queue
+		// If task is pinned, put WaitingBundle in local array
 		tls.PinnedTasks.push_back(std::make_pair(tls.CurrentFiberIndex, std::move(bundle)));
 	} else { 
-		// If not pinned, put it WaitingBundle in global array
+		// If not pinned, put WaitingBundle in global array
 		m_waitingBundles[tls.CurrentFiberIndex] = std::move(bundle);
 	}
 

--- a/source/task_scheduler.cpp
+++ b/source/task_scheduler.cpp
@@ -92,27 +92,50 @@ void TaskScheduler::FiberStart(void *arg) {
 		// Check if any of the waiting tasks are ready
 		std::size_t waitingFiberIndex = FTL_INVALID_INDEX;
 
-		for (std::size_t i = 0; i < taskScheduler->m_fiberPoolSize; ++i) {
-			// Double lock
-			if (!taskScheduler->m_waitingFibers[i].load(std::memory_order_relaxed)) {
-				continue;
-			}
+		// Check if there are any pinned tasks that are ready
+		ThreadLocalStorage &tls = taskScheduler->m_tls[taskScheduler->GetCurrentThreadIndex()];
 
-			if (!taskScheduler->m_waitingFibers[i].load(std::memory_order_acquire)) {
-				continue;
-			}
-
-			// Found a waiting fiber
-			// Test if it's ready
-			WaitingBundle *bundle = &taskScheduler->m_waitingBundles[i];
+		std::size_t pinnedTaskIndex = FTL_INVALID_INDEX;
+		for (std::size_t i = 0; i < tls.PinnedTasks.size(); i++) {
+			const std::pair<std::size_t, WaitingBundle>& entry = tls.PinnedTasks[i];
+			const WaitingBundle * bundle = &entry.second;
 			if (bundle->Counter->load(std::memory_order_relaxed) != bundle->TargetValue) {
 				continue;
+			} else {
+				pinnedTaskIndex = i;
+				waitingFiberIndex = entry.first;
 			}
-			
-			bool expected = true;
-			if (std::atomic_compare_exchange_weak_explicit(&taskScheduler->m_waitingFibers[i], &expected, false, std::memory_order_release, std::memory_order_relaxed)) {
-				waitingFiberIndex = i;
-				break;
+		}
+
+		// If we found a ready pinned task, remove from list
+		if (waitingFiberIndex != FTL_INVALID_INDEX) {
+			tls.PinnedTasks.erase(tls.PinnedTasks.begin() + pinnedTaskIndex);
+		}
+
+		// Check if there are any global tasks that are ready
+		if (waitingFiberIndex == FTL_INVALID_INDEX) {
+			for (std::size_t i = 0; i < taskScheduler->m_fiberPoolSize; ++i) {
+				// Double lock
+				if (!taskScheduler->m_waitingFibers[i].load(std::memory_order_relaxed)) {
+					continue;
+				}
+
+				if (!taskScheduler->m_waitingFibers[i].load(std::memory_order_acquire)) {
+					continue;
+				}
+
+				// Found a waiting fiber
+				// Test if it's ready
+				WaitingBundle *bundle = &taskScheduler->m_waitingBundles[i];
+				if (!bundle->Counter || bundle->Counter->load(std::memory_order_relaxed) != bundle->TargetValue) {
+					continue;
+				}
+
+				bool expected = true;
+				if (std::atomic_compare_exchange_weak_explicit(&taskScheduler->m_waitingFibers[i], &expected, false, std::memory_order_release, std::memory_order_relaxed)) {
+					waitingFiberIndex = i;
+					break;
+				}
 			}
 		}
 
@@ -396,7 +419,7 @@ void TaskScheduler::CleanUpOldFiber() {
 	}
 }
 
-void TaskScheduler::WaitForCounter(std::shared_ptr<std::atomic_uint> &counter, uint value) {
+void TaskScheduler::WaitForCounter(std::shared_ptr<std::atomic_uint> &counter, uint value, bool pinToCurrentThread) {
 	// Fast out
 	if (counter->load(std::memory_order_relaxed) == value) {
 		return;
@@ -405,9 +428,15 @@ void TaskScheduler::WaitForCounter(std::shared_ptr<std::atomic_uint> &counter, u
 	ThreadLocalStorage &tls = m_tls[GetCurrentThreadIndex()];
 
 	// Fill in the WaitingBundle data
-	WaitingBundle &bundle = m_waitingBundles[tls.CurrentFiberIndex];
-	bundle.Counter = counter.get();
-	bundle.TargetValue = value;
+	WaitingBundle bundle{ counter.get(), value };
+
+	if (pinToCurrentThread) {
+		// If task is pinned, put WaitingBundle in local queue
+		tls.PinnedTasks.push_back(std::make_pair(tls.CurrentFiberIndex, std::move(bundle)));
+	} else { 
+		// If not pinned, put it WaitingBundle in global array
+		m_waitingBundles[tls.CurrentFiberIndex] = std::move(bundle);
+	}
 
 	// Get a free fiber
 	std::size_t freeFiberIndex = GetNextFreeFiberIndex();


### PR DESCRIPTION
I implemented a local-to-thread list of tasks that are considered first when choosing new tasks, as discussed in issue #37. 

The list is implemented with a vector<> for the proof-of-concept, allowing for any number of pinned tasks at the moment. It works well for me, the main task remains on the main thread (see attached microprofile image).
![mp_big](https://cloud.githubusercontent.com/assets/395730/25780028/9bce9c8e-3321-11e7-85db-d65049b6989b.PNG)

