### PR TITLE
Fix for CMake errors if parent project also provides gtest

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -23,7 +23,7 @@
  ##
 
 # GTest
-if (FTL_BUILD_TESTS)
+if (FTL_BUILD_TESTS AND NOT TARGET gtest)
 	SET(gtest_force_shared_crt ON CACHE BOOL "Use the dll runtime" )
 	add_subdirectory(gtest)
 	set_target_properties(gtest PROPERTIES FOLDER third_party)


### PR DESCRIPTION
I'd argue that for ftl to be less intrusive, bringing in a relatively-common third-party target should also ensure that it doesn't break an existing implementation/CMake project.

Let me know if you'd rather the `gtest_force_shared_crt` flag be set regardless. Maybe that's safer if ftl requires it?