### PR TITLE
For Win32, refactor Windows.h dependency into implementation file, to…

### DIFF
--- a/include/ftl/thread_abstraction.h
+++ b/include/ftl/thread_abstraction.h
@@ -31,6 +31,20 @@
 
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
+
+#if !defined(_X86_) && defined(_M_IX86)
+#define _X86_
+#endif
+#if !defined(_AMD64_) && defined(_M_AMD64)
+#define _AMD64_
+#endif
+#if !defined(_ARM_) && defined(_M_ARM)
+#define _ARM_
+#endif
+#if !defined(_ARM64_) && defined(_M_ARM64)
+#define _ARM64_
+#endif
+
 #include <minwindef.h>
 
 #include <atomic>

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -94,16 +94,5 @@ add_library(ftl STATIC ${FIBER_TASKING_LIB_SRC})
 target_link_libraries(ftl boost_context ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(ftl PUBLIC ../include)
 
-# add definitions for windows targets
-if(FTL_ARCH STREQUAL "x86_64")
-	target_compile_definitions(ftl PRIVATE -D_AMD64_)
-elseif(FTL_ARCH STREQUAL "i386")
-	target_compile_definitions(ftl PRIVATE -D_X86_)
-elseif(FTL_ARCH STREQUAL "arm")
-	target_compile_definitions(ftl PRIVATE -D_ARM_)
-elseif(FTL_ARCH STREQUAL "arm64")
-	target_compile_definitions(ftl PRIVATE -D_ARM64_)
-endif()
-
 # Remove the prefix
 set_target_properties(ftl PROPERTIES PREFIX "")

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -64,7 +64,6 @@ if ((FTL_ARCH STREQUAL "x86_64") OR (FTL_ARCH STREQUAL "i386"))
 	add_definitions(-DFTL_STRONG_MEMORY_MODEL=1)
 endif()
 
-
 SetSourceGroup(NAME Core
 	PREFIX FTL
 	SOURCE_FILES 
@@ -82,6 +81,7 @@ SetSourceGroup(NAME Util
 	             ../include/ftl/fiber.h
 	             ../include/ftl/thread_abstraction.h
 	             ../include/ftl/wait_free_queue.h
+				 thread_abstraction.cpp
 )
 
 # Link all the sources into one
@@ -93,6 +93,17 @@ set(FIBER_TASKING_LIB_SRC
 add_library(ftl STATIC ${FIBER_TASKING_LIB_SRC})
 target_link_libraries(ftl boost_context ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(ftl PUBLIC ../include)
+
+# add definitions for windows targets
+if(FTL_ARCH STREQUAL "x86_64")
+	target_compile_definitions(ftl PRIVATE -D_AMD64_)
+elseif(FTL_ARCH STREQUAL "i386")
+	target_compile_definitions(ftl PRIVATE -D_X86_)
+elseif(FTL_ARCH STREQUAL "arm")
+	target_compile_definitions(ftl PRIVATE -D_ARM_)
+elseif(FTL_ARCH STREQUAL "arm64")
+	target_compile_definitions(ftl PRIVATE -D_ARM64_)
+endif()
 
 # Remove the prefix
 set_target_properties(ftl PROPERTIES PREFIX "")

--- a/source/task_scheduler.cpp
+++ b/source/task_scheduler.cpp
@@ -26,6 +26,9 @@
 
 #include "ftl/atomic_counter.h"
 
+#if defined(FTL_WIN32_THREADS)
+#include <Windows.h>
+#endif
 
 namespace ftl {
 

--- a/source/thread_abstraction.cpp
+++ b/source/thread_abstraction.cpp
@@ -1,0 +1,133 @@
+/** 
+ * FiberTaskingLib - A tasking library that uses fibers for efficient task switching
+ *
+ * This library was created as a proof of concept of the ideas presented by
+ * Christian Gyrling in his 2015 GDC Talk 'Parallelizing the Naughty Dog Engine Using Fibers'
+ *
+ * http://gdcvault.com/play/1022186/Parallelizing-the-Naughty-Dog-Engine
+ *
+ * FiberTaskingLib is the legal property of Adrian Astley
+ * Copyright Adrian Astley 2015 - 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "ftl/thread_abstraction.h"
+
+#include <cassert>
+#include <thread>
+
+
+#if defined(FTL_WIN32_THREADS)
+#include <Windows.h>
+
+#include <atomic>
+#include <process.h>
+
+
+namespace ftl {
+
+bool CreateThread(uint stackSize, ThreadStartRoutine startRoutine, void *arg, ThreadType *returnThread) {
+	HANDLE handle = reinterpret_cast<HANDLE>(_beginthreadex(nullptr, stackSize, startRoutine, arg, 0u, nullptr));
+//	SetThreadDescription(handle, L"ftl worker");
+
+	returnThread->Handle = handle;
+	returnThread->Id = GetThreadId(handle);
+
+	return handle != nullptr;
+}
+
+bool CreateThread(uint stackSize, ThreadStartRoutine startRoutine, void *arg, size_t coreAffinity, ThreadType *returnThread) {
+	HANDLE handle = reinterpret_cast<HANDLE>(_beginthreadex(nullptr, stackSize, startRoutine, arg, CREATE_SUSPENDED, nullptr));
+//	SetThreadDescription(handle, L"ftl worker");
+	if (handle == nullptr) {
+		return false;
+	}
+
+	DWORD_PTR mask = 1ull << coreAffinity;
+	SetThreadAffinityMask(handle, mask);
+	
+	returnThread->Handle = handle;
+	returnThread->Id = GetThreadId(handle);
+	ResumeThread(handle);
+
+	return true;
+}
+
+void EndCurrentThread() {
+	_endthreadex(0);
+}
+
+void JoinThread(ThreadType thread) {
+	WaitForSingleObject(thread.Handle, INFINITE);
+}
+
+ThreadType GetCurrentThread() {
+	Win32Thread result{
+		::GetCurrentThread(),
+		::GetCurrentThreadId()
+	};
+
+	return result;
+}
+
+void SetCurrentThreadAffinity(size_t coreAffinity) {
+	SetThreadAffinityMask(::GetCurrentThread(), coreAffinity);
+}
+
+void CreateEvent(EventType *event) {
+	event->event = ::CreateEvent(nullptr, TRUE, FALSE, nullptr);
+	event->countWaiters = 0;
+}
+
+void CloseEvent(EventType eventId) {
+	CloseHandle(eventId.event);
+}
+
+#pragma warning( push )
+#pragma warning( disable : 4189 )
+void WaitForEvent(EventType &eventId, uint32 milliseconds) {
+	eventId.countWaiters.fetch_add(1u);
+	DWORD retval = WaitForSingleObject(eventId.event, milliseconds);
+	uint prev = eventId.countWaiters.fetch_sub(1u);
+	if (1 == prev) {
+		// we were the last to awaken, so reset event.
+		ResetEvent(eventId.event);
+	}
+	assert(retval != WAIT_FAILED);
+	assert(prev != 0);
+}
+#pragma warning ( pop )
+
+void SignalEvent(EventType eventId) {
+	SetEvent(eventId.event);
+}
+
+} // End of namespace ftl
+
+#endif
+
+
+namespace ftl {
+	
+uint GetNumHardwareThreads() {
+	return std::thread::hardware_concurrency();
+}
+
+void YieldThread() {
+	std::this_thread::yield();
+}
+	
+} // End of namespace ftl


### PR DESCRIPTION
… avoid pushing header dependency onto users.