### PR TITLE
Fix some Valgrind issues

### DIFF
--- a/include/ftl/atomic_counter.h
+++ b/include/ftl/atomic_counter.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "ftl/config.h"
 #include "ftl/typedefs.h"
 
 #include <atomic>
@@ -54,6 +55,10 @@ public:
 	AtomicCounter(TaskScheduler *taskScheduler, uint initialValue = 0) 
 			: m_taskScheduler(taskScheduler),
 			  m_value(initialValue) {
+		FTL_VALGRIND_HG_DISABLE_CHECKING(&m_value, sizeof(m_value));
+		FTL_VALGRIND_HG_DISABLE_CHECKING(&m_lock, sizeof(m_lock));
+		FTL_VALGRIND_HG_DISABLE_CHECKING(m_freeSlots, sizeof(m_freeSlots[0]) * NUM_WAITING_FIBER_SLOTS);
+
 		for (uint i = 0; i < NUM_WAITING_FIBER_SLOTS; ++i) {
 			m_freeSlots[i].store(true);
 			// We initialize InUse to true to prevent CheckWaitingFibers() from checking garbage
@@ -86,6 +91,7 @@ private:
 				  TargetValue(0), 
 				  FiberStoredFlag(nullptr),
 				  PinnedThreadIndex(0) {
+			FTL_VALGRIND_HG_DISABLE_CHECKING(&InUse, sizeof(InUse));
 		}
 
 		/** 

--- a/include/ftl/config.h
+++ b/include/ftl/config.h
@@ -52,3 +52,13 @@
 		#define FTL_POSIX_THREADS
 	#endif
 #endif
+
+#if defined(FTL_VALGRIND)
+	#include <valgrind/valgrind.h>
+	#include <valgrind/helgrind.h>
+
+	#define FTL_VALGRIND_HG_DISABLE_CHECKING(s, e) VALGRIND_HG_DISABLE_CHECKING(s, e)
+#else
+	#define FTL_VALGRIND_HG_DISABLE_CHECKING(s, e)
+#endif
+

--- a/include/ftl/fiber.h
+++ b/include/ftl/fiber.h
@@ -107,7 +107,7 @@ public:
 		m_stack = AlignedAlloc(m_systemPageSize + m_stackSize + m_systemPageSize, m_systemPageSize);
 		m_context = boost_context::make_fcontext(static_cast<char *>(m_stack) + m_systemPageSize + stackSize, stackSize, startRoutine);
 		
-		FTL_VALGRIND_REGISTER(static_cast<char *>(m_stack) + m_systemPageSize + stackSize, static_cast<char *>(m_stack) + m_systemPageSize);
+		FTL_VALGRIND_REGISTER(static_cast<char *>(m_stack) + m_systemPageSize, static_cast<char *>(m_stack) + m_systemPageSize + stackSize);
 		#if defined(FTL_FIBER_STACK_GUARD_PAGES)
 			MemoryGuard(static_cast<char *>(m_stack), m_systemPageSize);
 			MemoryGuard(static_cast<char *>(m_stack) + m_systemPageSize + stackSize, m_systemPageSize);

--- a/include/ftl/wait_free_queue.h
+++ b/include/ftl/wait_free_queue.h
@@ -47,6 +47,9 @@ public:
 		: m_top(1), // m_top and m_bottom must start at 1
 		  m_bottom(1), // Otherwise, the first Pop on an empty queue will underflow m_bottom
 		  m_array(new CircularArray(32)) {
+		FTL_VALGRIND_HG_DISABLE_CHECKING(&m_top, sizeof(m_top));
+		FTL_VALGRIND_HG_DISABLE_CHECKING(&m_bottom, sizeof(m_bottom));
+		FTL_VALGRIND_HG_DISABLE_CHECKING(&m_array, sizeof(m_array));
 	}
 	~WaitFreeQueue() {
 		delete m_array.load(std::memory_order_relaxed);

--- a/source/task_scheduler.cpp
+++ b/source/task_scheduler.cpp
@@ -228,6 +228,8 @@ TaskScheduler::TaskScheduler()
 	  m_fibers(nullptr), 
 	  m_freeFibers(nullptr), 
 	  m_tls(nullptr) {
+	FTL_VALGRIND_HG_DISABLE_CHECKING(&m_initialized, sizeof(m_initialized));
+	FTL_VALGRIND_HG_DISABLE_CHECKING(&m_quit, sizeof(m_quit));
 }
 
 TaskScheduler::~TaskScheduler() {
@@ -246,6 +248,7 @@ void TaskScheduler::Run(uint fiberPoolSize, TaskFunction mainTask, void *mainTas
 	m_fiberPoolSize = fiberPoolSize;
 	m_fibers = new Fiber[fiberPoolSize];
 	m_freeFibers = new std::atomic<bool>[fiberPoolSize];
+	FTL_VALGRIND_HG_DISABLE_CHECKING(m_freeFibers, sizeof(std::atomic<bool>) * fiberPoolSize);
 
 	for (uint i = 0; i < fiberPoolSize; ++i) {
 		m_fibers[i] = std::move(Fiber(512000, FiberStart, this));

--- a/tests/producer_consumer/producer_consumer.cpp
+++ b/tests/producer_consumer/producer_consumer.cpp
@@ -54,6 +54,7 @@ void Producer(ftl::TaskScheduler *taskScheduler, void *arg) {
 
 void ProducerConsumerMainTask(ftl::TaskScheduler *taskScheduler, void *arg) {
 	std::atomic_uint globalCounter(0u);
+	FTL_VALGRIND_HG_DISABLE_CHECKING(&globalCounter, sizeof(globalCounter));
 
 	ftl::Task tasks[kNumProducerTasks];
 	for (uint i = 0; i < kNumProducerTasks; ++i) {


### PR DESCRIPTION
1. Fix order of `VALGRIND_REGISTER` parameters. Unfortunately Valgrind still complains about stack switch even with this. The documentation warns that this request is unreliable.

2. Add Helgrind (Valgrind thread error detector) annotation macro. I've added it to `config.h` instead of the existing block in `fiber.h` because it's needed in places which don't include `fiber.h`

3. Mark atomic variables for Helgrind. Even though they're `std::atomic`, Helgrind can't see this in the final executable without help.