### PR TITLE
Allow dynamically allocated size of fiber wait lists with ftl::AtomicCounter

### DIFF
--- a/include/ftl/atomic_counter.h
+++ b/include/ftl/atomic_counter.h
@@ -51,7 +51,7 @@ class AtomicCounter {
 #define NUM_WAITING_FIBER_SLOTS 4
 
 public:
-	explicit AtomicCounter(TaskScheduler *taskScheduler, uint initialValue = 0);
+	explicit AtomicCounter(TaskScheduler *taskScheduler, uint initialValue = 0, uint fiberSlots = NUM_WAITING_FIBER_SLOTS);
 
 private:
 	/* The TaskScheduler this counter is associated with */
@@ -89,7 +89,7 @@ private:
 		 */
 		std::size_t PinnedThreadIndex;
 	};
-	WaitingFiberBundle m_waitingFibers[NUM_WAITING_FIBER_SLOTS];
+	std::vector<WaitingFiberBundle> m_waitingFibers;
 
 	/**
 	* We friend TaskScheduler so we can keep AddFiberToWaitingList() private

--- a/include/ftl/atomic_counter.h
+++ b/include/ftl/atomic_counter.h
@@ -48,7 +48,9 @@ class AtomicCounter {
  * If a user tries to have more fibers wait on a counter, the fiber will not be tracked,
  * which will cause WaitForCounter() to infinitely sleep. This will probably cause a hang
  */
-#define NUM_WAITING_FIBER_SLOTS 4
+#ifndef NUM_WAITING_FIBER_SLOTS
+	#define NUM_WAITING_FIBER_SLOTS 4
+#endif
 
 public:
 	explicit AtomicCounter(TaskScheduler *taskScheduler, uint initialValue = 0, uint fiberSlots = NUM_WAITING_FIBER_SLOTS);

--- a/source/atomic_counter.cpp
+++ b/source/atomic_counter.cpp
@@ -110,7 +110,7 @@ bool AtomicCounter::AddFiberToWaitingList(std::size_t fiberIndex, uint targetVal
 }
 
 void AtomicCounter::CheckWaitingFibers(uint value) {
-	uint readyFiberIndices[m_waitingFibers.size()];
+	std::vector<uint> readyFiberIndices(m_waitingFibers.size(), 0);
 	uint nextIndex = 0;
 
 	for (uint i = 0; i < m_waitingFibers.size(); ++i) {


### PR DESCRIPTION
This should solve the problems that we talked about in #66 about the amount of things that can wait on an atomic counter. It isn't perfect as it isn't dynamic, but that would require a lockfree list and that's a lot of work and overhead for what should be a simple job.