### PR TITLE
Added fix for C2064 at config.h(90) in VS 15.9.11

### DIFF
--- a/include/ftl/config.h
+++ b/include/ftl/config.h
@@ -87,7 +87,7 @@
 
 namespace ftl {
 #ifdef __cpp_lib_hardware_interference_size
-constexpr static std::size_t kCacheLineSize = std::hardware_destructive_interference_size();
+constexpr static std::size_t kCacheLineSize = std::hardware_destructive_interference_size;
 #else
 constexpr static std::size_t kCacheLineSize = 64;
 #endif


### PR DESCRIPTION
"error C2064: term does not evaluate to a function taking 0 arguments"