### PR TITLE
Fixed FTL's use of CMAKE_SOURCE_DIR breaking macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 add_subdirectory(third_party)
 
 # Warning flags
-include(${CMAKE_SOURCE_DIR}/cmake/CheckAndAddFlag.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CheckAndAddFlag.cmake)
 
 if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
 	Check_And_Add_Flag(-fdiagnostics-color=always)


### PR DESCRIPTION
If you call ADD_SUBDIRECTORY on ftl from within a macro, CMAKE_SOURCE_DIR will be relative to that macro's location, not the ftl file.