### PR TITLE
Add ftl::fibtex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build*/
 
 # CLion Project files
 .idea/
+# CLion build files
+cmake-build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,12 @@ if (FTL_BUILD_TESTS)
 	include(CTest)
 endif()
 
+# MSVC Iterator Issues
+if (MSVC)
+	add_definitions(-D_ITERATOR_DEBUG_LEVEL=1)
+endif()
+
+
 set(CMAKE_CXX_STANDARD 11) # C++11...
 set(CMAKE_CXX_STANDARD_REQUIRED ON) #...is required...
 set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11

--- a/include/ftl/config.h
+++ b/include/ftl/config.h
@@ -59,6 +59,14 @@
 #	endif
 #endif
 
+//  SSE on MSVC x86                MSVC x64 has SSE              Clang/GCC define
+#if _M_IX86_FP >= 1 || (defined(_M_AMD64) || defined(_M_X64)) || defined(__SSE__)
+#   include <emmintrin.h>
+#   define FTL_PAUSE() _mm_pause()
+#else
+#   define FTL_PAUSE()
+#endif
+
 #if defined(FTL_POSIX_THREADS)
 #	define FTL_NOINLINE_POSIX __attribute__((noinline))
 #	define FTL_NOINLINE_WIN32

--- a/include/ftl/fibtex.h
+++ b/include/ftl/fibtex.h
@@ -1,0 +1,208 @@
+/**
+ * FiberTaskingLib - A tasking library that uses fibers for efficient task switching
+ *
+ * This library was created as a proof of concept of the ideas presented by
+ * Christian Gyrling in his 2015 GDC Talk 'Parallelizing the Naughty Dog Engine Using Fibers'
+ *
+ * http://gdcvault.com/play/1022186/Parallelizing-the-Naughty-Dog-Engine
+ *
+ * FiberTaskingLib is the legal property of Adrian Astley
+ * Copyright Adrian Astley 2015 - 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "atomic_counter.h"
+#include "task_scheduler.h"
+#include <cassert>
+#include <mutex>
+#include <system_error>
+
+namespace ftl {
+// Pull std helpers into ftl namespace
+using std::adopt_lock;
+using std::defer_lock;
+using std::try_to_lock;
+
+/**
+ * A fiber aware mutex. Does not block in the traditional way. Methods do not follow the lowerCamelCase convention
+ * of the rest of the library in order to comply with C++'s named requirement Basic Lockable and Lockable.
+ */
+class Fibtex {
+public:
+	/**
+	 * All Fibtex's have to be aware of the task scheduler in order to yield.
+	 *
+	 * @param taskScheduler    ftl::TaskScheduler that will be using this mutex.
+	 * @param fiberSlots       How many fibers can simultaneously wait on the mutex
+	 */
+	explicit Fibtex(TaskScheduler *taskScheduler, uint fiberSlots = NUM_WAITING_FIBER_SLOTS)
+	        : m_ableToSpin(taskScheduler->GetThreadCount() > 1), m_taskScheduler(taskScheduler),
+	          m_atomicCounter(taskScheduler, 0, fiberSlots) {
+	}
+
+	Fibtex(const Fibtex &) = delete;
+	Fibtex(Fibtex &&that) = delete;
+	Fibtex &operator=(const Fibtex &) = delete;
+	Fibtex &operator=(Fibtex &&that) = delete;
+
+	~Fibtex() = default;
+
+	/**
+	 * Lock mutex in traditional way, yielding immediately.
+	 */
+	// ReSharper disable once CppInconsistentNaming
+	void lock(bool const pinToThread = false) {
+		while (true) {
+			if (m_atomicCounter.CompareExchange(0, 1, std::memory_order_acq_rel)) {
+				return;
+			}
+
+			m_taskScheduler->WaitForCounter(&m_atomicCounter, 0, pinToThread);
+		}
+	}
+
+	/**
+	 * Lock mutex using a finite spinlock. Does not spin if there is only one backing thread.
+	 *
+	 * @param pinToThread    If the fiber should resume on the same thread as it started on pre-lock.
+	 * @param iterations     Amount of iterations to spin before yielding.
+	 */
+	// ReSharper disable once CppInconsistentNaming
+	void lock_spin(bool const pinToThread = false, uint const iterations = 1000) {
+		// Don't spin if there is only one thread and spinning is pointless
+		if (!m_ableToSpin) {
+			lock(pinToThread);
+			return;
+		}
+
+		// Spin for a bit
+		for (uint i = 0; i < iterations; ++i) {
+			// Spin
+			if (m_atomicCounter.CompareExchange(0, 1, std::memory_order_acq_rel)) {
+				return;
+			}
+			FTL_PAUSE();
+		}
+
+		// Spinning didn't grab the lock, we're in for the long haul. Yield.
+		lock(pinToThread);
+	}
+
+	/**
+	 * Lock mutex using an infinite spinlock. Does not spin if there is only one backing thread.
+	 */
+	// ReSharper disable once CppInconsistentNaming
+	void lock_spin_infinite(bool const pinToThread = false) {
+		// Don't spin if there is only one thread and spinning is pointless
+		if (!m_ableToSpin) {
+			lock(pinToThread);
+			return;
+		}
+
+		while (true) {
+			// Spin
+			if (m_atomicCounter.CompareExchange(0, 1, std::memory_order_acq_rel)) {
+				return;
+			}
+			FTL_PAUSE();
+		}
+	}
+
+	/**
+	 * Attempts to lock the lock a single time.
+	 *
+	 * @return    If lock successful.
+	 */
+	// ReSharper disable once CppInconsistentNaming
+	bool try_lock() {
+		return m_atomicCounter.CompareExchange(0, 1, std::memory_order_acq_rel);
+	}
+
+	/**
+	 * Unlock the mutex.
+	 */
+	// ReSharper disable once CppInconsistentNaming
+	void unlock() {
+		if (!m_atomicCounter.CompareExchange(1, 0, std::memory_order_acq_rel)) {
+			FTL_ASSERT("Error: Mutex was unlocked by another fiber or was double unlocked.", false);
+		}
+	}
+
+private:
+	bool m_ableToSpin;
+	TaskScheduler *m_taskScheduler;
+	AtomicCounter m_atomicCounter;
+};
+
+enum class FibtexLockBehavior {
+	Traditional,
+	Spin,
+	SpinInfinite,
+};
+
+/**
+ * A wrapper class that encapsulates pinToThread, and the various spin behaviors
+ */
+class LockWrapper {
+public:
+	/**
+	 * @param mutex             Fibtex to wrap around.
+	 * @param behavior          How to lock the underlying Fibtex
+	 * @param pinToThread       If the fiber should resume on the same thread as it started on pre-lock.
+	 * @param spinIterations    If behavior == Spin, this gives the amount of iterations to spin before yielding. Ignored otherwise.
+	 */
+	LockWrapper(Fibtex &mutex, FibtexLockBehavior behavior, bool pinToThread = false, uint spinIterations = 1000)
+	        : m_mutex(mutex), m_pinToThread(pinToThread), m_behavior(behavior), m_spinIterations(spinIterations) {
+	}
+	/**
+	 * Locks mutex
+	 */
+	void lock() {
+		switch (m_behavior) {
+		case FibtexLockBehavior::Traditional:
+			m_mutex.lock(m_pinToThread);
+			break;
+		case FibtexLockBehavior::Spin:
+			m_mutex.lock_spin(m_pinToThread, m_spinIterations);
+			break;
+		case FibtexLockBehavior::SpinInfinite:
+			m_mutex.lock_spin_infinite(m_pinToThread);
+			break;
+		}
+	}
+	/**
+	 * Tries to lock mutex
+	 *
+	 * @return    If mutex successfully locked.
+	 */
+	bool try_lock() {
+		return m_mutex.try_lock();
+	}
+	/**
+	 * Unlocks mutex.
+	 */
+	void unlock() const {
+		m_mutex.unlock();
+	}
+
+private:
+	Fibtex &m_mutex;
+	bool m_pinToThread;
+	FibtexLockBehavior m_behavior;
+	uint m_spinIterations;
+};
+
+} // namespace ftl

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -80,6 +80,7 @@ SetSourceGroup(NAME Util
 	SOURCE_FILES ../include/ftl/assert.h
 	             ../include/ftl/config.h
 	             ../include/ftl/fiber.h
+	             ../include/ftl/fibtex.h
 	             ../include/ftl/thread_abstraction.h
 	             ../include/ftl/thread_local.h
 	             ../include/ftl/wait_free_queue.h

--- a/source/task_scheduler.cpp
+++ b/source/task_scheduler.cpp
@@ -311,7 +311,7 @@ void TaskScheduler::Run(uint const fiberPoolSize, TaskFunction const mainTask, v
 
 void TaskScheduler::AddTask(Task const task, AtomicCounter *const counter) {
 	if (counter != nullptr) {
-		counter->Store(1);
+		counter->FetchAdd(1);
 	}
 
 	const TaskBundle bundle = {task, counter};
@@ -334,7 +334,7 @@ void TaskScheduler::AddTask(Task const task, AtomicCounter *const counter) {
 
 void TaskScheduler::AddTasks(uint const numTasks, Task const *const tasks, AtomicCounter *const counter) {
 	if (counter != nullptr) {
-		counter->Store(numTasks);
+		counter->FetchAdd(numTasks);
 	}
 
 	ThreadLocalStorage &tls = m_tls[GetCurrentThreadIndex()];

--- a/source/task_scheduler.cpp
+++ b/source/task_scheduler.cpp
@@ -46,6 +46,7 @@ FTL_THREAD_FUNC_RETURN_TYPE TaskScheduler::ThreadStart(void *const arg) {
 	// Spin wait until everything is initialized
 	while (!taskScheduler->m_initialized.load(std::memory_order_acquire)) {
 		// Spin
+		FTL_PAUSE();
 	}
 
 	// Get a free fiber to switch to

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,11 @@ SetSourceGroup(NAME "Fiber Abstraction"
 	             fiber_abstraction/floating_point_fiber_switch.cpp
 )
 
+SetSourceGroup(NAME "Fibtex"
+	PREFIX FTL_TEST
+	SOURCE_FILES fibtex/locking_tests.cpp
+)
+
 SetSourceGroup(NAME "Producer Consumer"
 	PREFIX FTL_TEST
 	SOURCE_FILES producer_consumer/producer_consumer.cpp
@@ -53,6 +58,7 @@ SetSourceGroup(NAME "Utilities"
 set(FIBER_TASKING_LIB_TESTS_SRC
 	${FTL_TEST_FIBER_ABSTRACTION}
 	${FTL_TEST_PRODUCER_CONSUMER}
+	${FTL_TEST_FIBTEX}
 	${FTL_TEST_TRIANGLE_NUMBER}
 	${FTL_TEST_UTILITIES}
 )

--- a/tests/fibtex/locking_tests.cpp
+++ b/tests/fibtex/locking_tests.cpp
@@ -1,0 +1,91 @@
+/**
+ * FiberTaskingLib - A tasking library that uses fibers for efficient task switching
+ *
+ * This library was created as a proof of concept of the ideas presented by
+ * Christian Gyrling in his 2015 GDC Talk 'Parallelizing the Naughty Dog Engine Using Fibers'
+ *
+ * http://gdcvault.com/play/1022186/Parallelizing-the-Naughty-Dog-Engine
+ *
+ * FiberTaskingLib is the legal property of Adrian Astley
+ * Copyright Adrian Astley 2015 - 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ftl/fibtex.h"
+#include "ftl/task_scheduler.h"
+
+#include <atomic>
+#include <gtest/gtest.h>
+
+struct MutexData {
+	MutexData(ftl::TaskScheduler *scheduler) : Lock(scheduler, 6), Counter(0) {
+	}
+
+	ftl::Fibtex Lock;
+	uint Counter;
+	std::vector<uint> Queue;
+};
+
+void LockGuardTest(ftl::TaskScheduler * /*scheduler*/, void *arg) {
+	auto *data = reinterpret_cast<MutexData *>(arg);
+
+	std::lock_guard<ftl::Fibtex> lg(data->Lock);
+	data->Queue.push_back(data->Counter++);
+}
+
+void SpinLockGuardTest(ftl::TaskScheduler * /*scheduler*/, void *arg) {
+	auto *data = reinterpret_cast<MutexData *>(arg);
+
+	ftl::LockWrapper wrapper(data->Lock, ftl::FibtexLockBehavior::Spin);
+	std::lock_guard<ftl::LockWrapper> lg(wrapper);
+	data->Queue.push_back(data->Counter++);
+}
+
+void InfiniteSpinLockGuardTest(ftl::TaskScheduler * /*scheduler*/, void *arg) {
+	auto *data = reinterpret_cast<MutexData *>(arg);
+
+	ftl::LockWrapper wrapper(data->Lock, ftl::FibtexLockBehavior::SpinInfinite);
+	std::lock_guard<ftl::LockWrapper> lg(wrapper);
+	data->Queue.push_back(data->Counter++);
+}
+
+void FutexMainTask(ftl::TaskScheduler *taskScheduler, void *) {
+	MutexData md(taskScheduler);
+
+	ftl::AtomicCounter c(taskScheduler);
+
+	constexpr std::size_t iterations = 20000;
+	for (std::size_t i = 0; i < iterations; ++i) {
+		taskScheduler->AddTask(ftl::Task{LockGuardTest, &md}, &c);
+		taskScheduler->AddTask(ftl::Task{LockGuardTest, &md}, &c);
+		taskScheduler->AddTask(ftl::Task{SpinLockGuardTest, &md}, &c);
+		taskScheduler->AddTask(ftl::Task{SpinLockGuardTest, &md}, &c);
+		taskScheduler->AddTask(ftl::Task{InfiniteSpinLockGuardTest, &md}, &c);
+		taskScheduler->AddTask(ftl::Task{InfiniteSpinLockGuardTest, &md}, &c);
+
+		taskScheduler->WaitForCounter(&c, 0);
+	}
+
+	GTEST_ASSERT_EQ(md.Counter, 6 * iterations);
+	GTEST_ASSERT_EQ(md.Queue.size(), 6 * iterations);
+	for (uint i = 0; i < md.Counter; ++i) {
+		GTEST_ASSERT_EQ(md.Queue[i], i);
+	}
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+TEST(FunctionalTests, LockingTests) {
+	ftl::TaskScheduler taskScheduler;
+	taskScheduler.Run(400, FutexMainTask, nullptr, 0, ftl::EmptyQueueBehavior::Yield);
+}


### PR DESCRIPTION
This is a re-submit of #66, after some fixes and rebasing/squashing.

Closes #64 

This adds a Fiber-aware mutex implementation. The member functions are named so they can be used with std::lockable-type classes (unique_lock, lock_guard, etc.)
