### PR TITLE
WIP: Remove the need to specify a MainTaskFunc

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -17,97 +17,99 @@ http://twvideo01.ubm-us.net/o1/vault/gdc2015/presentations/Gyrling_Christian_Par
 ## Example
 [source,cc]
 ----
-#include <ftl/task_scheduler.h>
-#include <ftl/atomic_counter.h>
+#include "ftl/atomic_counter.h"
+#include "ftl/task_scheduler.h"
 
+#include <assert.h>
+#include <stdint.h>
 
 struct NumberSubset {
-    uint64 start;
-    uint64 end;
+	uint64_t start;
+	uint64_t end;
 
-    uint64 total;
+	uint64_t total;
 };
 
-
 void AddNumberSubset(ftl::TaskScheduler *taskScheduler, void *arg) {
-    NumberSubset *subset = reinterpret_cast<NumberSubset *>(arg);
+	NumberSubset *subset = reinterpret_cast<NumberSubset *>(arg);
 
-    subset->total = 0;
+	subset->total = 0;
 
-    while (subset->start != subset->end) {
-        subset->total += subset->start;
-        ++subset->start;
-    }
+	while (subset->start != subset->end) {
+		subset->total += subset->start;
+		++subset->start;
+	}
 
-    subset->total += subset->end;
+	subset->total += subset->end;
 }
-
 
 /**
-* Calculates the value of a triangle number by dividing the additions up into tasks
-*
-* A triangle number is defined as:
-*         Tn = 1 + 2 + 3 + ... + n
-*
-* The code is checked against the numerical solution which is:
-*         Tn = n * (n + 1) / 2
-*/
-void TriangleNumberMainTask(ftl::TaskScheduler *taskScheduler, void *arg) {
-    // Define the constants to test
-    const uint64 triangleNum = 47593243ull;
-    const uint64 numAdditionsPerTask = 10000ull;
-    const uint64 numTasks = (triangleNum + numAdditionsPerTask - 1ull) / numAdditionsPerTask;
-
-    // Create the tasks
-    // FTL allows you to create Tasks on the stack. 
-    // However, in this case, that would cause a stack overflow
-    ftl::Task *tasks = new ftl::Task[numTasks];
-    NumberSubset *subsets = new NumberSubset[numTasks];
-    uint64 nextNumber = 1ull;
-
-    for (uint64 i = 0ull; i < numTasks; ++i) {
-        NumberSubset *subset = &subsets[i];
-
-        subset->start = nextNumber;
-        subset->end = nextNumber + numAdditionsPerTask - 1ull;
-        if (subset->end > triangleNum) {
-            subset->end = triangleNum;
-        }
-
-        tasks[i] = {AddNumberSubset, subset};
-
-        nextNumber = subset->end + 1;
-    }
-
-    // Schedule the tasks
-    ftl::AtomicCounter counter(taskScheduler);
-    taskScheduler->AddTasks(numTasks, tasks, &counter);
-
-    // FTL creates its own copies of the tasks, so we can safely delete the memory
-    delete[] tasks;
-
-    // Wait for the tasks to complete
-    taskScheduler->WaitForCounter(&counter, 0);
-
-
-    // Add the results
-    uint64 result = 0ull;
-    for (uint64 i = 0; i < numTasks; ++i) {
-        result += subsets[i].total;
-    }
-
-    // Test
-    assert(triangleNum * (triangleNum + 1ull) / 2ull == result);
-
-    // Cleanup
-    delete[] subsets;
-}
-
+ * Calculates the value of a triangle number by dividing the additions up into tasks
+ *
+ * A triangle number is defined as:
+ *         Tn = 1 + 2 + 3 + ... + n
+ *
+ * The code is checked against the numerical solution which is:
+ *         Tn = n * (n + 1) / 2
+ */
 int main(int argc, char *argv) {
-    ftl::TaskScheduler taskScheduler;
-    taskScheduler.Run(25, TriangleNumberMainTask);
+	// Create the task scheduler and bind the main thread to it
+	ftl::TaskScheduler taskScheduler;
+	taskScheduler.Init();
 
-    return 0;
+	// Define the constants to test
+	constexpr uint64_t triangleNum = 47593243ull;
+	constexpr uint64_t numAdditionsPerTask = 10000ull;
+	constexpr uint64_t numTasks = (triangleNum + numAdditionsPerTask - 1ull) / numAdditionsPerTask;
+
+	// Create the tasks
+	// FTL allows you to create Tasks on the stack.
+	// However, in this case, that would cause a stack overflow
+	ftl::Task *tasks = new ftl::Task[numTasks];
+	NumberSubset *subsets = new NumberSubset[numTasks];
+	uint64_t nextNumber = 1ull;
+
+	for (uint64_t i = 0ull; i < numTasks; ++i) {
+		NumberSubset *subset = &subsets[i];
+
+		subset->start = nextNumber;
+		subset->end = nextNumber + numAdditionsPerTask - 1ull;
+		if (subset->end > triangleNum) {
+			subset->end = triangleNum;
+		}
+
+		tasks[i] = {AddNumberSubset, subset};
+
+		nextNumber = subset->end + 1;
+	}
+
+	// Schedule the tasks
+	ftl::AtomicCounter counter(&taskScheduler);
+	taskScheduler.AddTasks(numTasks, tasks, &counter);
+
+	// FTL creates its own copies of the tasks, so we can safely delete the memory
+	delete[] tasks;
+
+	// Wait for the tasks to complete
+	taskScheduler.WaitForCounter(&counter, 0);
+
+	// Add the results
+	uint64_t result = 0ull;
+	for (uint64_t i = 0; i < numTasks; ++i) {
+		result += subsets[i].total;
+	}
+
+	// Test
+	assert(triangleNum * (triangleNum + 1ull) / 2ull == result);
+
+	// Cleanup
+	delete[] subsets;
+	delete[] tasks;
+
+	// The destructor of TaskScheduler will shut down all the worker threads
+	// and unbind the main thread
+
+	return 0;
 }
 ----
 

--- a/include/ftl/fiber.h
+++ b/include/ftl/fiber.h
@@ -145,7 +145,7 @@ private:
 	size_t m_stackSize{0};
 	boost_context::fcontext_t m_context{nullptr};
 	void *m_arg{nullptr};
-	FTL_VALGRIND_ID
+	FTL_VALGRIND_ID;
 
 public:
 	/**

--- a/tests/fibtex/locking_tests.cpp
+++ b/tests/fibtex/locking_tests.cpp
@@ -62,21 +62,27 @@ void InfiniteSpinLockGuardTest(ftl::TaskScheduler * /*scheduler*/, void *arg) {
 	data->Queue.push_back(data->Counter++);
 }
 
-void FutexMainTask(ftl::TaskScheduler *taskScheduler, void *) {
-	MutexData md(taskScheduler);
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+TEST(FunctionalTests, LockingTests) {
+	ftl::TaskScheduler taskScheduler;
+	ftl::TaskSchedulerInitOptions options;
+	options.Behavior = ftl::EmptyQueueBehavior::Yield;
+	GTEST_ASSERT_EQ(taskScheduler.Init(options), 0);
 
-	ftl::AtomicCounter c(taskScheduler);
+	MutexData md(&taskScheduler);
+
+	ftl::AtomicCounter c(&taskScheduler);
 
 	constexpr size_t iterations = 20000;
 	for (size_t i = 0; i < iterations; ++i) {
-		taskScheduler->AddTask(ftl::Task{LockGuardTest, &md}, &c);
-		taskScheduler->AddTask(ftl::Task{LockGuardTest, &md}, &c);
-		taskScheduler->AddTask(ftl::Task{SpinLockGuardTest, &md}, &c);
-		taskScheduler->AddTask(ftl::Task{SpinLockGuardTest, &md}, &c);
-		taskScheduler->AddTask(ftl::Task{InfiniteSpinLockGuardTest, &md}, &c);
-		taskScheduler->AddTask(ftl::Task{InfiniteSpinLockGuardTest, &md}, &c);
+		taskScheduler.AddTask(ftl::Task{LockGuardTest, &md}, &c);
+		taskScheduler.AddTask(ftl::Task{LockGuardTest, &md}, &c);
+		taskScheduler.AddTask(ftl::Task{SpinLockGuardTest, &md}, &c);
+		taskScheduler.AddTask(ftl::Task{SpinLockGuardTest, &md}, &c);
+		taskScheduler.AddTask(ftl::Task{InfiniteSpinLockGuardTest, &md}, &c);
+		taskScheduler.AddTask(ftl::Task{InfiniteSpinLockGuardTest, &md}, &c);
 
-		taskScheduler->WaitForCounter(&c, 0);
+		taskScheduler.WaitForCounter(&c, 0);
 	}
 
 	GTEST_ASSERT_EQ(md.Counter, 6 * iterations);
@@ -84,10 +90,4 @@ void FutexMainTask(ftl::TaskScheduler *taskScheduler, void *) {
 	for (unsigned i = 0; i < md.Counter; ++i) {
 		GTEST_ASSERT_EQ(md.Queue[i], i);
 	}
-}
-
-// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
-TEST(FunctionalTests, LockingTests) {
-	ftl::TaskScheduler taskScheduler;
-	taskScheduler.Run(400, FutexMainTask, nullptr, 0, ftl::EmptyQueueBehavior::Yield);
 }

--- a/tests/triangle_number/calc_triangle_num.cpp
+++ b/tests/triangle_number/calc_triangle_num.cpp
@@ -58,7 +58,11 @@ void AddNumberSubset(ftl::TaskScheduler * /*scheduler*/, void *arg) {
  *
  * TODO: Use gtest's 'Value Parameterized Tests' to test multiple triangle numbers
  */
-void TriangleNumberMainTask(ftl::TaskScheduler *taskScheduler, void * /*arg*/) {
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+TEST(FunctionalTests, CalcTriangleNum) {
+	ftl::TaskScheduler taskScheduler;
+	GTEST_ASSERT_EQ(taskScheduler.Init(), 0);
+
 	// Define the constants to test
 	const uint64_t triangleNum = 47593243ULL;
 	const uint64_t numAdditionsPerTask = 10000ULL;
@@ -85,11 +89,11 @@ void TriangleNumberMainTask(ftl::TaskScheduler *taskScheduler, void * /*arg*/) {
 	}
 
 	// Schedule the tasks and wait for them to complete
-	ftl::AtomicCounter counter(taskScheduler);
-	taskScheduler->AddTasks(numTasks, tasks, &counter);
+	ftl::AtomicCounter counter(&taskScheduler);
+	taskScheduler.AddTasks(numTasks, tasks, &counter);
 	delete[] tasks;
 
-	taskScheduler->WaitForCounter(&counter, 0);
+	taskScheduler.WaitForCounter(&counter, 0);
 
 	// Add the results
 	uint64_t result = 0ULL;
@@ -102,10 +106,4 @@ void TriangleNumberMainTask(ftl::TaskScheduler *taskScheduler, void * /*arg*/) {
 
 	// Cleanup
 	delete[] subsets;
-}
-
-// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
-TEST(FunctionalTests, CalcTriangleNum) {
-	ftl::TaskScheduler taskScheduler;
-	taskScheduler.Run(400, TriangleNumberMainTask);
 }


### PR DESCRIPTION
Before:
```
void MainFunction(void *arg) {
    // Call AddTasks(), WaitForCounter(), etc.
}

int main() {
    taskScheduler.Run(..., MainFunction);
}
```

With this change:
```
int main() {
    taskScheduler.Init(...);

    // Call AddTasks(), WaitForCounter(), etc.
}
```

Some thoughts so far:

I think it's much clearer to the user with this format. The code flows naturally.
However, it does mean FTL's internal cleanup is a little bit grosser. But I feel like that's an ok tradeoff. The end-user is going to look at their code more than we look at FTL.

I kind of want to have RAII for Init() / Term(). However, I don't really like doing so much allocation / work / potential for failure inside constructors / destructors. So *shrug*.

TODO:

- Update docs with new style
- Audit TaskScheduler member function initialization / destruction to make sure they're properly set up / destroyed in Init() / Term()