### PR TITLE
Add ScopeLock

### DIFF
--- a/include/ftl/fibtex.h
+++ b/include/ftl/fibtex.h
@@ -204,6 +204,20 @@ private:
 	bool m_pinToThread;
 	FibtexLockBehavior m_behavior;
 	unsigned m_spinIterations;
+};	
+
+class ScopeLock {
+public:
+    ScopeLock(ftl::Fibtex& fibtex, bool pinToThread = false): fibtex{fibtex} {
+        fibtex.lock(pinToThread);
+    };
+
+	~ScopeLock() {
+	    fibtex.unlock();
+	};
+
+private:
+	ftl::Fibtex& fibtex;
 };
 
 } // namespace ftl


### PR DESCRIPTION
`ScopeLock` locks a Fibtex when it's created, and unlocks that Fibtex when it's destructed. This makes it very easy to use C++ syntax to describe the synchronized area of your code base

You may optionally pin the lock to a thread, but you don't have to