### PR TITLE
Fix race with ReadyFibersLock

### DIFF
--- a/source/task_scheduler.cpp
+++ b/source/task_scheduler.cpp
@@ -678,6 +678,7 @@ void TaskScheduler::AddReadyFiber(size_t const pinnedThreadIndex, ReadyFiberBund
 		const EmptyQueueBehavior behavior = m_emptyQueueBehavior.load(std::memory_order::memory_order_relaxed);
 		if (behavior == EmptyQueueBehavior::Sleep) {
 			if (GetCurrentThreadIndex() != pinnedThreadIndex) {
+				std::unique_lock<std::mutex> lock(ThreadSleepLock);
 				// Kick all threads
 				ThreadSleepCV.notify_all();
 			}


### PR DESCRIPTION
The race remains :(. To fix it, I introduce locking the threadsleeplock where it matters.