### PR TITLE
Use an atomic bitfield for m_freeFibers instead of an array of atomic<bool>

### DIFF
--- a/include/ftl/task_scheduler.h
+++ b/include/ftl/task_scheduler.h
@@ -168,11 +168,12 @@ private:
 	/* The backing storage for the fiber pool */
 	Fiber *m_fibers{nullptr};
 	/**
-	 * An array of atomics, which signify if a fiber is available to be used. The indices of m_waitingFibers
-	 * correspond 1 to 1 with m_fibers. So, if m_freeFibers[i] == true, then m_fibers[i] can be used.
-	 * Each atomic acts as a lock to ensure that threads do not try to use the same fiber at the same time
+	 * A bitfield which signifies if a fiber is available to be used. The bit indices of m_freeFibers
+	 * correspond 1 to 1 with the array indices of m_fibers. So if bit X of m_freeFibers is set, then
+	 * m_fibers[X] can be used. The bits act as a lock to ensure that threads do not try to use the
+	 * same fiber at the same time
 	 */
-	std::atomic<bool> *m_freeFibers{nullptr};
+	std::atomic<uint64_t> *m_freeFibers{nullptr};
 	/**
 	 * An array of ReadyFiberBundle which is used by @WaitForCounter()
 	 *


### PR DESCRIPTION
The idea being that we can use less atomic memory fetches / memory
thrashing.

Another approach would be to still use the array of atomic<bool>,
but have the threads start from a random index each time. To do
this we would need to have a prng initialized and seeded in TLS.
(PCG could work well / be fast and simple).

Thus, GetNextFreeFiberIndex() would first query the prng in order to
get the start index, and then it would search from startIndex and loop
around to startIndex - 1. (the current behavior iterates from 0 to
m_fiberPoolSize)