### PR TITLE
Fix incorrect memory fences for WaitFreeQueue

### DIFF
--- a/include/ftl/wait_free_queue.h
+++ b/include/ftl/wait_free_queue.h
@@ -121,11 +121,7 @@ public:
 		}
 		array->Put(b, value);
 
-#if defined(FTL_STRONG_MEMORY_MODEL)
-		std::atomic_signal_fence(std::memory_order_release);
-#else
 		std::atomic_thread_fence(std::memory_order_release);
-#endif
 
 		m_bottom.store(b + 1, std::memory_order_relaxed);
 	}
@@ -162,11 +158,7 @@ public:
 	bool Steal(T *const value) {
 		uint64_t t = m_top.load(std::memory_order_acquire);
 
-#if defined(FTL_STRONG_MEMORY_MODEL)
-		std::atomic_signal_fence(std::memory_order_seq_cst);
-#else
 		std::atomic_thread_fence(std::memory_order_seq_cst);
-#endif
 
 		uint64_t const b = m_bottom.load(std::memory_order_acquire);
 		if (t < b) {

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -62,10 +62,6 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
 	set(FTL_ARCH "arm64")
 endif()
 
-if ((FTL_ARCH STREQUAL "x86_64") OR (FTL_ARCH STREQUAL "i386"))
-	add_definitions(-DFTL_STRONG_MEMORY_MODEL=1)
-endif()
-
 SetSourceGroup(NAME Core
 	PREFIX FTL
 	SOURCE_FILES 


### PR DESCRIPTION
This is a reversion of 85c11b61da5e69f81e6710d569d266c6c503ad84

I was confused when applying the optimizations there.
We do need full memory barriers. This matches the
paper now.

Addresses #137

Thanks @martty for walking through it with me.