### PR TITLE
Fix vendored nonius in C++20

### DIFF
--- a/ci_scripts/travis_ci_install_osx.sh
+++ b/ci_scripts/travis_ci_install_osx.sh
@@ -2,7 +2,7 @@
 set -x #echo on
 
 brew update
-brew cask uninstall oclint
+brew uninstall --force oclint
 
 upgradeBrewFormula () {
 	if brew ls --versions $1 > /dev/null

--- a/third_party/nonius/include/nonius/detail/benchmark_function.hpp
+++ b/third_party/nonius/include/nonius/detail/benchmark_function.hpp
@@ -40,14 +40,14 @@ namespace nonius {
         /// it may be slow, but it is consistently slow.
         struct benchmark_function {
         private:
-            struct concept {
+            struct n_concept {
                 virtual benchmark_function call(parameters params) const = 0;
                 virtual void call(chronometer meter) const = 0;
-                virtual concept* clone() const = 0;
-                virtual ~concept() = default;
+                virtual n_concept* clone() const = 0;
+                virtual ~n_concept() = default;
             };
             template <typename Fun>
-            struct model : public concept {
+            struct model : public n_concept {
                 model(Fun&& fun) : fun(std::move(fun)) {}
                 model(Fun const& fun) : fun(fun) {}
 
@@ -115,7 +115,7 @@ namespace nonius {
             benchmark_function operator()(parameters params) const { return f->call(params); }
             void operator()(chronometer meter) const { f->call(meter); }
         private:
-            std::unique_ptr<concept> f;
+            std::unique_ptr<n_concept> f;
         };
     } // namespace detail
 } // namespace nonius

--- a/third_party/nonius/include/nonius/detail/complete_invoke.hpp
+++ b/third_party/nonius/include/nonius/detail/complete_invoke.hpp
@@ -42,8 +42,15 @@ namespace nonius {
                 return {};
             }
         };
+#if __cplusplus < 201703L
+        // std::result_of was deprecated in C++17 and removed in C++20
+
         template <typename Sig>
         using ResultOf = typename std::result_of<Sig>::type;
+#else
+        template <typename Sig>
+        using ResultOf = typename std::invoke_result_t<Sig>;
+#endif
 
         // invoke and not return void :(
         template <typename Fun, typename... Args>


### PR DESCRIPTION
C++17 deprecated `std::result_of`, C++20 removed it. I've switched nonius's usage of `std::result_of` to `std::invoke_result_t`